### PR TITLE
Several refactors:

### DIFF
--- a/errored.go
+++ b/errored.go
@@ -17,10 +17,16 @@ package errored
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"runtime"
 	"strings"
+)
+
+var (
+	// AlwaysTrace will, if set globally, enable tracing on all errors.
+	AlwaysTrace bool
+	// AlwaysDebug will, if set globally, enable debug messages on all errors.
+	AlwaysDebug bool
 )
 
 type errorStack struct {
@@ -32,34 +38,63 @@ type errorStack struct {
 // Error is our custom error with description, file, and line.
 type Error struct {
 	desc  string
-	stack []errorStack
+	stack [][]errorStack
+	trace bool
+	debug bool
+}
+
+// SetTrace enables the tracing capabilities of errored's Error struct.
+//
+// Please note that SetTrace automatically sets debug mode too if enabled. See SetDebug.
+func (e *Error) SetTrace(trace bool) {
+	e.trace = trace
+	if trace {
+		e.debug = trace
+	}
+}
+
+// SetDebug enables the per-error caller information of errored's Error struct.
+func (e *Error) SetDebug(debug bool) {
+	e.debug = debug
+}
+
+// Combine combines two errors into a single one.
+func (e *Error) Combine(e2 *Error) *Error {
+	return &Error{
+		desc:  fmt.Sprintf("%v: %v", e.desc, e2.desc),
+		stack: append(e.stack, e2.stack...),
+	}
 }
 
 // Error() allows *core.Error to present the `error` interface.
 func (e *Error) Error() string {
-	var ret string
-
-	if os.Getenv("CONTIV_TRACE") != "" {
-		ret = e.desc + "\n"
+	if e.trace || AlwaysTrace {
+		ret := e.desc + "\n"
 
 		for _, stack := range e.stack {
-			ret += fmt.Sprintf("%s [%s %d]\n", stack.fun, stack.file, stack.line)
+			for _, line := range stack {
+				ret += fmt.Sprintf("\t%s [%s %d]\n", line.fun, line.file, line.line)
+			}
 		}
-	} else {
-		ret = fmt.Sprintf("%s [%s %s %d]", e.desc, e.stack[0].fun, e.stack[0].file, e.stack[0].line)
+
+		return ret
+	} else if (e.debug || AlwaysDebug) && len(e.stack) > 0 && len(e.stack[0]) > 0 {
+		return fmt.Sprintf("%s [%s %s %d]", e.desc, e.stack[0][0].fun, e.stack[0][0].file, e.stack[0][0].line)
 	}
 
-	return ret
+	return e.desc
 }
 
 // Errorf returns an *Error based on the format specification provided.
 func Errorf(f string, args ...interface{}) *Error {
 	e := &Error{
-		stack: []errorStack{},
+		stack: [][]errorStack{},
 		desc:  fmt.Sprintf(f, args...),
 	}
 
 	i := 1
+
+	errors := []errorStack{}
 
 	for {
 		stack := errorStack{}
@@ -75,10 +110,12 @@ func Errorf(f string, args ...interface{}) *Error {
 
 		stack.file = path.Base(file)
 		stack.line = line
-		e.stack = append(e.stack, stack)
+		errors = append(errors, stack)
 
 		i++
 	}
+
+	e.stack = append(e.stack, errors)
 
 	return e
 }


### PR DESCRIPTION
- Debug and Trace modes, Debug shows the line the error was created on, trace
  is lower-level and shows the full backtrace. Set with SetTrace and SetDebug
  respectively.
- Remove references to CONTIV_\* environment variables. They can be set inside
  the programs.
- New Method: Combine(): which combines two errors into a new one, including
  stack traces and descriptions.
- AlwaysTrace and AlwaysDebug are used to globally enable the debug/trace
  functionality.

/cc @mapuri 

Signed-off-by: Erik Hollensbe <erik+github@hollensbe.org>
