### PR TITLE
Support for status codes

### DIFF
--- a/errored.go
+++ b/errored.go
@@ -61,6 +61,8 @@ type errorStack struct {
 
 // Error is our custom error with description, file, and line.
 type Error struct {
+	Code int
+
 	desc  string
 	stack [][]errorStack
 	trace bool
@@ -92,8 +94,15 @@ func (e *Error) Combine(e2 *Error) *Error {
 
 // Error() allows *core.Error to present the `error` interface.
 func (e *Error) Error() string {
+	desc := e.desc
+	if e.Code != 0 {
+		desc = fmt.Sprintf("%d %v", e.Code, desc)
+	} else {
+		desc = fmt.Sprintf("%v", desc)
+	}
+
 	if e.trace || AlwaysTrace {
-		ret := e.desc + "\n"
+		ret := desc + "\n"
 
 		for _, stack := range e.stack {
 			for _, line := range stack {
@@ -103,10 +112,10 @@ func (e *Error) Error() string {
 
 		return ret
 	} else if (e.debug || AlwaysDebug) && len(e.stack) > 0 && len(e.stack[0]) > 0 {
-		return fmt.Sprintf("%s [%s %s %d]", e.desc, e.stack[0][0].fun, e.stack[0][0].file, e.stack[0][0].line)
+		return fmt.Sprintf("%s [%s %s %d]", desc, e.stack[0][0].fun, e.stack[0][0].file, e.stack[0][0].line)
 	}
 
-	return e.desc
+	return desc
 }
 
 // Errorf returns an *Error based on the format specification provided.

--- a/errored_test.go
+++ b/errored_test.go
@@ -104,3 +104,11 @@ func TestAlways(t *testing.T) {
 		t.Fatalf("Trace output was not provided in error: %q", e.Error())
 	}
 }
+
+func TestCode(t *testing.T) {
+	e := Errorf("error")
+	e.Code = 100
+	if e.Error() != "100 error" {
+		t.Fatalf("Error code output did not equal expectation: %v", e.Error())
+	}
+}


### PR DESCRIPTION
These allow errors to be compared against constants easily without compromising the functionality of the error message... e.g., a caller handling an error does not need to scrape the error message, or use a static one, to determine that it's the right error.

This will be very useful in communicating statuses between volplugin's subsystems, so PTAL.
